### PR TITLE
Task name mistake

### DIFF
--- a/docs-page.html
+++ b/docs-page.html
@@ -506,7 +506,7 @@ task('foo', function () {
 });
 
 desc('This is the bar task.');
-task('foo', function () {
+task('bar', function () {
   console.log('This is the bar task.');
 });
 


### PR DESCRIPTION
`bar` task was named `'foo'`