### PR TITLE
Fix card links on the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,7 +225,7 @@
                     directory in your project, and load them (using require) after loading your main
                     Jakefile.
                 </div>
-                  <a class="card-link-mask" href="docs-page.html#section-utility-tasks"></a>
+                  <a class="card-link-mask" href="docs-page.html#item-advanced-usage-modularizing"></a>
                 </div><!--//card-body-->
               </div><!--//card-->
             </div><!--//col-->

--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
                     <code>reenable</code> methods, make Jake infinitely
                     programmable.
                 </div>
-                  <a class="card-link-mask" href="docs-page.html#item-advanced-usage-modularizing"></a>
+                  <a class="card-link-mask" href="docs-page.html#item-advanced-usage-programmatic-tasks"></a>
                 </div><!--//card-body-->
               </div><!--//card-->
             </div><!--//col-->

--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
                     not a file-task defined for it, Jake can create file-tasks on the fly
                     from Rules.
                 </div>
-                  <a class="card-link-mask" href="docs-page.html#item-advanced-usage-programmatic-tasks"></a>
+                  <a class="card-link-mask" href="docs-page.html#item-api-rules"></a>
                 </div><!--//card-body-->
               </div><!--//card-->
             </div><!--//col-->


### PR DESCRIPTION
## Summary

Right now the card links on the homepage are messed up: they link to the wrong sections in the docs, which is kind of confusing. 🤷🏻‍♂️